### PR TITLE
Application Safety

### DIFF
--- a/src/neo-vm/OpCode.cs
+++ b/src/neo-vm/OpCode.cs
@@ -37,10 +37,10 @@
         JMPIFNOT = 0x64,
         CALL = 0x65,
         RET = 0x66,
-        SAFE_APPCALL = 0x67,
+        UNSAFE_APPCALL = 0x67,
         SYSCALL = 0x68,
         TAILCALL = 0x69,
-        UNSAFE_APPCALL = 0x70,
+        SAFE_APPCALL = 0x70,
 
         // Stack
         DUPFROMALTSTACK = 0x6A,

--- a/src/neo-vm/OpCode.cs
+++ b/src/neo-vm/OpCode.cs
@@ -37,10 +37,10 @@
         JMPIFNOT = 0x64,
         CALL = 0x65,
         RET = 0x66,
-        APPCALL = 0x67,
+        SAFE_APPCALL = 0x67,
         SYSCALL = 0x68,
         TAILCALL = 0x69,
-
+        UNSAFE_APPCALL = 0x70,
 
         // Stack
         DUPFROMALTSTACK = 0x6A,

--- a/src/neo-vm/ScriptBuilder.cs
+++ b/src/neo-vm/ScriptBuilder.cs
@@ -35,7 +35,14 @@ namespace Neo.VM
         {
             if (scriptHash.Length != 20)
                 throw new ArgumentException();
-            return Emit(useTailCall ? OpCode.TAILCALL : OpCode.APPCALL, scriptHash);
+            return Emit(useTailCall ? OpCode.TAILCALL : OpCode.SAFE_APPCALL, scriptHash);
+        }
+
+        public ScriptBuilder EmitUnsafeAppCall(byte[] scriptHash)
+        {
+            if (scriptHash.Length != 20)
+                throw new ArgumentException();
+            return Emit(OpCode.UNSAFE_APPCALL, scriptHash);
         }
 
         public ScriptBuilder EmitJump(OpCode op, short offset)


### PR DESCRIPTION
Change `APPCALL` to `SAFE_APPCALL` and add new `UNSAFE_APPCALL` opcode. `SAFE_APPCALL` does not allow an application to call another contract.

This PR makes the default behavior of `APPCALL` disallow any contract from calling another contract.  Applications that need to allow calling of another contract from within their contract should use `UNSAFE_APPCALL` instead and behavior will be the same as current.

This allows current wallet implementations to remain mostly unchanged but gain a great amount of safety.  For example, a wallet making an NEP5 transfer request will not need to update its implementation.

Applications calling contracts that use the `RegisterAppCall` or `DynamicAppCall` functionalities should use `UNSAFE_APPCALL` when constructing their `InvocationTransaction`.

Related `neo-python` changes here: https://github.com/CityOfZion/neo-python/compare/development...appcall-fix?expand=1